### PR TITLE
Add distance to comparison page

### DIFF
--- a/Skidom/resorthub/templates/resorthub/compare.html
+++ b/Skidom/resorthub/templates/resorthub/compare.html
@@ -1,21 +1,31 @@
 {% extends "skidom_base.html" %}
 {% load static %}
+{% load resort_filters %}
+{% load widget_tweaks %}
 
 {% block content %}
 <div class ="supres">
     <table>
-        <tr class = "d0">
-            <td>Name</td>
-            <td>State</td>
-            <td>Website</td>
-        </tr>
+        <thead>
+                <tr class = "d0">
+                    <th>Name</th>
+                    <th>State</th>
+                    <th>Website</th>
+                    <th>Distance</th>
+                    <th>Driving Time</th>
+                </tr>
+        </thead>
+        <tbody>
         {% for resort in resorts %}
             <tr>
                 <td class="name">{{ resort.name }}</td>
                 <td class="general"> {{ resort.address.locality.state.name }} </td>
                 <td class="general"><a href="{{ resort.web_home }}">Here</a></td>
+                <td class="onehun">{{ distances|use_index:forloop.counter0  }}</td>
+                <td class="general">{{ times|use_index:forloop.counter0 }}</td>
             </tr>    
         {% endfor %}
+        </tbody>
    </table>
 </div>
 

--- a/Skidom/resorthub/views.py
+++ b/Skidom/resorthub/views.py
@@ -46,7 +46,14 @@ def resort_listing(request):
                         except:
                             starting_address = "Boston MA"
 
-                return render(request, 'resorthub/compare.html', {'resorts': selected_resorts})
+                resort_addresses = [x.address.raw for x in selected_resorts] 
+                clean_dists, clean_times = use_googlemaps(starting_address, resort_addresses)
+
+                return render(request, 'resorthub/compare.html', {
+                    'resorts': selected_resorts,
+                    'distances': clean_dists,
+                    'times': clean_times,
+                })
  
         elif ("favorite" in request.POST):
             if not request.user.is_authenticated():

--- a/Skidom/resorthub/views.py
+++ b/Skidom/resorthub/views.py
@@ -38,10 +38,13 @@ def resort_listing(request):
                 else:
                     g = GeoIP2()
                     ip = request.META.get('REMOTE_ADDR', None)
+
                     if ip:
-                        starting_address = g.city(ip)['city']
-                    else:
-                        starting_address = "Boston MA"
+                        try:
+                            geoip_city = g.city(ip)
+                            starting_address = geoip_city['city']
+                        except:
+                            starting_address = "Boston MA"
 
                 return render(request, 'resorthub/compare.html', {'resorts': selected_resorts})
  


### PR DESCRIPTION
Test plan
- Navigate to the resorts page
- Select a few resorts and select "compare"
- Verify that distance and time are displayed in the resulting table